### PR TITLE
added dependency to auto generate the spring-configuration-metadata-json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-web'
     api 'org.springframework.boot:spring-boot-starter-security'
     api 'org.projectlombok:lombok'
+    api 'org.springframework.boot:spring-boot-configuration-processor'
 
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-web'
     api 'org.springframework.boot:spring-boot-starter-security'
     api 'org.projectlombok:lombok'
-    api 'org.springframework.boot:spring-boot-configuration-processor'
 
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.fasterxml.jackson.core:jackson-annotations'


### PR DESCRIPTION
Fixes #1 

The plugin will automatically create the file "META-INF/spring-configuration-metadata-json" that will be used by the IDE to autocomplete the properties that are defined with the @ConfigurationProperties annotation
